### PR TITLE
Black Formatting, Type Hints, Works on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ VENV/
 
 # Rope project settings
 .ropeproject
+
+# Jetbrains
+.idea/

--- a/githubtakeout.py
+++ b/githubtakeout.py
@@ -201,8 +201,7 @@ def run(
     # type: (str, str, str, bool, bool, bool, bool) -> None
     working_dir = os.path.join(base_dir, "backups")
     user, repos, gists, token = get_user(username, prompt_token)
-    repos = user.get_repos()
-    num_repos = len([1 for _ in repos])
+    num_repos = repos.totalCount
     if not list_only:
         logger.info(f"creating archives in: {working_dir}\n")
     logger.info(f'found {num_repos} repos for user "{username}"\n')
@@ -214,8 +213,7 @@ def run(
         else:
             clone_and_archive_repo(url, local_repo_dir, archive_format, include_history)
     if include_gists:
-        gists = user.get_gists()
-        num_gists = len([1 for _ in gists])
+        num_gists = gists.totalCount
         logger.info("")
         logger.info(f'found {num_gists} gists for user "{username}"\n')
         for gist in gists:
@@ -225,11 +223,7 @@ def run(
                 logger.info(url)
             else:
                 clone_and_archive_repo(
-                    url,
-                    local_repo_dir,
-                    archive_format,
-                    include_history,
-                    is_gist=True,
+                    url, local_repo_dir, archive_format, include_history, is_gist=True
                 )
 
 

--- a/githubtakeout.py
+++ b/githubtakeout.py
@@ -5,7 +5,6 @@ import getpass
 import logging
 import os
 import stat
-import shutil
 import tarfile
 import urllib
 import zipfile
@@ -53,7 +52,7 @@ def archive(local_repo_dir, archive_format="zip", is_gist=False):
     return archive_path
 
 
-# On windows, you can frequently get permssion errors trying to delete
+# On windows, you can frequently get permission errors trying to delete
 # .git artifacts in the downloaded archive
 def safe_unlink(path: Path):
     if not path.exists():
@@ -70,7 +69,7 @@ def safe_unlink(path: Path):
             logger.info(f"Failed to delete file {path}: {e}")
 
 
-# shutil.rmtree follows sylinks and doesn't handle read-only files or permission errors cleanly
+# shutil.rmtree follows symlinks and doesn't handle read-only files or permission errors cleanly
 def safe_rmtree(path: str):
     path = Path(path)
     if not path.exists():


### PR DESCRIPTION
# Overview
This PR does a few things, I can split them into separate PRs if you're interested in taking any of them.

&check; Update gitignore to take into account Jetbrains IDEs (I used PyCharm to edit this)
&check; Apply [Black](https://github.com/psf/black) for deterministic formatting
&check; Apply type hints to all types that had ambiguities, now you know for sure what everything is and your IDE will yell at you (if you have it configured) when it detects a violation
&check; Added safer directory deletion. The current code can trigger [symlink attacks](https://docs.python.org/3/library/shutil.html#shutil.rmtree), since you're both downloading and then executing rmtree on arbitrary files, which could be symlinks, pointing at sensitive local data, depending on version of rmtree being used.
&check; Added more robust error handling around deleting files, specifically around the deletion of .git files on windows. Previously this would crash the program on the deletion step of the first repo.
&check; Rename all names that were performing shadowing (like `list`, `zip`)