### PR TITLE
Require Python 3.12+, rmtree() readonly, and other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ VENV/
 
 # Rope project settings
 .ropeproject
+
+# Jetbrains
+.idea/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ as tarballs (`.tar.gz`) using the `--format=tar` option.
 
 ## Requirements:
 
-- Python 3.9+
+- Python 3.12+
 - Git 1.7+
 - Python packages:
     - GitPython

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,16 +11,13 @@ license-files = ["LICENSE"]
 authors = [{name = "Corey Goldberg"}]
 maintainers = [{name = "Corey Goldberg"}]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">= 3.12"
 keywords = ["git", "github", "archive", "backup", "export", "takeout"]
 classifiers = [
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13"
 ]


### PR DESCRIPTION
This PR changes the minimum required Python version to 3.12.

It also adds an error handler for `shutil.rmtree()` so it can delete directories/files with readonly permissions.