### PR TITLE
Fix repo deletion on Windows, KeyboardInterrupt, and refactoring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "githubtakeout"
-version = "0.1.3dev0"
+version = "0.1.3dev1"
 description = "Archive public Git Repos and Gists from GitHub"
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
This [hopefully] fixes the bug where .git directories can't be deleted on Windows.  Also catch `KeyboardInterrupt` to exit on Ctl-C, and some refactoring.