### PR TITLE
Validate --format choices and show defaults in --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,19 +61,19 @@ If you prefer to be prompted for your token each time you run the program, use t
 ### CLI Options:
 
 ```
-usage: githubtakeout [-h] [--dir DIR] [--format FORMAT] [--gists] [--history] [--list] [--token] username
+usage: githubtakeout [-h] [--dir DIR] [--format {tar,zip}] [--gists] [--history] [--list] [--token] username
 
 positional arguments:
-  username         GitHub username
+  username            github username
 
 options:
-  -h, --help       show this help message and exit
-  --dir DIR        output directory
-  --format FORMAT  archive format (tar, zip)
-  --gists          include gists
-  --history        include commit history and branches (.git directory)
-  --list           list repos only
-  --token          prompt for auth toke
+  -h, --help          show this help message and exit
+  --dir DIR           output directory (default: ./)
+  --format {tar,zip}  archive format (default: zip)
+  --gists             include gists
+  --history           include commit history and branches (.git directory)
+  --list              list repos only
+  --token             prompt for auth token
 ```
 
 ## Usage Examples:

--- a/src/githubtakeout.py
+++ b/src/githubtakeout.py
@@ -22,6 +22,8 @@ import github
 
 from progress import GitProgress
 
+ARCHIVE_FORMATS = ("tar", "zip")
+
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
 
@@ -48,7 +50,7 @@ def add_creds(url, username, token):
 
 
 def archive(local_repo_dir, archive_format="zip", is_gist=False):
-    if archive_format not in ("tar", "zip"):
+    if archive_format not in ARCHIVE_FORMATS:
         raise ValueError(f"{archive_format} is not a valid archive format")
     base_name = os.path.basename(local_repo_dir)
     extension = "tar.gz" if archive_format == "tar" else archive_format
@@ -222,8 +224,17 @@ def main():
         sys.exit("sorry, this program requires Python 3.12+")
     parser = argparse.ArgumentParser()
     parser.add_argument("username", help="github username")
-    parser.add_argument("--dir", default=os.getcwd(), help="output directory")
-    parser.add_argument("--format", default="zip", help="archive format (tar, zip)")
+    parser.add_argument(
+        "--dir",
+        default=os.getcwd(),
+        help="output directory (default: ./)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=ARCHIVE_FORMATS,
+        default="zip",
+        help="archive format (default: %(default)s)",
+    )
     parser.add_argument(
         "--gists", action="store_true", default=False, help="include gists"
     )


### PR DESCRIPTION
Slightly improves UX and slightly more self describing.

```console
$ .venv/bin/githubtakeout --format json
usage: githubtakeout [-h] [--dir DIR] [--format {tar,zip}] [--gists] [--history] [--list] [--token] username
githubtakeout: error: argument --format: invalid choice: 'json' (choose from tar, zip)
```